### PR TITLE
chore: refacto http request authorization

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -1,6 +1,21 @@
 package provider
 
+import (
+	"io"
+	"net/http"
+)
+
 type LitellmClient struct {
 	ApiToken   string `tfsdk:"api_token"`
 	ApiBaseURL string `tfsdk:"api_base_url"`
+}
+
+func (c *LitellmClient) NewRequest(method string, url string, body io.Reader) (*http.Request, error) {
+	request, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("Authorization", "Bearer "+c.ApiToken)
+	return request, nil
 }

--- a/provider/resource_model.go
+++ b/provider/resource_model.go
@@ -73,13 +73,10 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/new", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -130,13 +127,10 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/update", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -171,13 +165,10 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/delete", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Instead of repeating each time the header to set in the http request to authenticate with litellm. We can have the LitellmClient generate an http.Request with already the header for authentication + content-type

It will be more useful in the future when adding other litellm api (user, team, ...)