### PR TITLE
Add litellm team api

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -1,6 +1,21 @@
 package provider
 
+import (
+	"io"
+	"net/http"
+)
+
 type LitellmClient struct {
 	ApiToken   string `tfsdk:"api_token"`
 	ApiBaseURL string `tfsdk:"api_base_url"`
+}
+
+func (c *LitellmClient) NewRequest(method string, url string, body io.Reader) (*http.Request, error) {
+	request, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("Authorization", "Bearer "+c.ApiToken)
+	return request, nil
 }

--- a/provider/litellm/role.go
+++ b/provider/litellm/role.go
@@ -1,0 +1,28 @@
+package litellm
+
+type Role string
+
+const (
+	PROXY_ADMIN          = "proxy_admin"
+	PROXY_ADMIN_VIEWER   = "proxy_admin_viewer"
+	ORG_ADMIN            = "org_admin"
+	INTERNAL_USER        = "internal_user"
+	INTERNAL_USER_VIEWER = "internal_user_viewer"
+)
+
+var ROLE_LIST = map[Role]string{
+	PROXY_ADMIN:          "proxy_admin",
+	PROXY_ADMIN_VIEWER:   "proxy_admin_viewer",
+	ORG_ADMIN:            "org_admin",
+	INTERNAL_USER:        "internal_user",
+	INTERNAL_USER_VIEWER: "internal_user_viewer",
+}
+
+func ValidateRole(inputRole string) (Role, bool) {
+	for role, strValue := range ROLE_LIST {
+		if strValue == inputRole {
+			return role, true
+		}
+	}
+	return "", false
+}

--- a/provider/litellm/team.go
+++ b/provider/litellm/team.go
@@ -1,0 +1,18 @@
+package litellm
+
+type TeamInfoResponse struct {
+	TeamId   string `json:"team_id"`
+	TeamInfo struct {
+		TeamAlias        string            `json:"team_alias"`
+		TeamId           string            `json:"team_id"`
+		OrganizationId   string            `json:"organization_id"`
+		MembersWithRoles []MemberWithRole  `json:"members_with_roles"`
+		Metadata         map[string]string `json:"metadata"`
+		TpmLimit         int               `json:"tpm_limit"`
+		RpmLimit         int               `json:"rpm_limit"`
+		MaxBudget        float64           `json:"max_budget"`
+		BudgetDuration   string            `json:"budget_duration"`
+		Models           []string          `json:"models"`
+		Blocked          bool              `json:"blocked"`
+	} `json:"team_info"`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -26,6 +26,7 @@ func NewProvider() *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"litellm_model": resourceModel(),
+			"litellm_team":  resourceTeam(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/provider/resource_model.go
+++ b/provider/resource_model.go
@@ -73,13 +73,10 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/new", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -130,13 +127,10 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/update", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -171,13 +165,10 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/delete", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/provider/resource_team.go
+++ b/provider/resource_team.go
@@ -1,0 +1,270 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gzamboni/terraform-provider-litellm/provider/litellm"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var ResourceTeamSchema = map[string]*schema.Schema{
+	"team_alias": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Required:    false,
+		Description: "User defined team alias",
+	},
+	"team_id": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Required:    false,
+		Description: "The team id of the user. if none passed, we'll generate it",
+	},
+	"metadata": {
+		Type:        schema.TypeMap,
+		Required:    false,
+		Optional:    true,
+		Description: "Metadata for team, store information for team",
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
+	"tpm_limit": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "The TPM (Tokens Per Minute) limit for this team - all keys with this team_id will have at max this TPM limit",
+	},
+	"rpm_limit": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "The RPM (Requests Per Minute) limit for this team - all keys associated with this team_id will have at max this RPM limit",
+	},
+	"max_budget": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "The maximum budget allocated to the team - all keys for this team_id will have at max this max_budget",
+	},
+	"budget_duration": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "The duration of the budget for the team",
+	},
+	"models": {
+		Type:        schema.TypeSet,
+		Required:    false,
+		Optional:    true,
+		Description: "A list of models associated with the team - all keys for this team_id will have at most, these models. If empty, assumes all models are allowed",
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
+	"blocked": {
+		Type:        schema.TypeBool,
+		Required:    false,
+		Optional:    true,
+		Description: "Flag indicating if the team is blocked or not - will stop all calls from keys with this team_id.",
+		Default:     false,
+	},
+}
+
+type Team struct {
+	TeamAlias      string            `json:"team_alias,omitempty"`
+	TeamId         string            `json:"team_id,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	TpmLimit       int               `json:"tpm_limit,omitempty"`
+	RpmLimit       int               `json:"rpm_limit,omitempty"`
+	MaxBudget      float64           `json:"max_budget,omitempty"`
+	BudgetDuration string            `json:"budget_duration,omitempty"`
+	Models         []string          `json:"models,omitempty"`
+	Blocked        bool              `json:"blocked,omitempty"`
+}
+
+func resourceTeam() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTeamCreate,
+		ReadContext:   resourceTeamRead,
+		UpdateContext: resourceTeamUpdate,
+		DeleteContext: resourceTeamDelete,
+		Schema:        ResourceTeamSchema,
+	}
+}
+
+func getTeamFromResourceData(d *schema.ResourceData) Team {
+	m := d.Get("metadata").(map[string]interface{})
+	metadata := make(map[string]string)
+	for k, v := range m {
+		metadata[k] = fmt.Sprintf("%v", v)
+	}
+
+	mo := d.Get("models").(*schema.Set)
+	var models []string
+	for _, value := range mo.List() {
+		models = append(models, fmt.Sprintf("%v", value))
+	}
+
+	team := Team{
+		TeamAlias:      d.Get("team_alias").(string),
+		TeamId:         d.Get("team_id").(string),
+		Metadata:       metadata,
+		TpmLimit:       d.Get("tpm_limit").(int),
+		RpmLimit:       d.Get("rpm_limit").(int),
+		MaxBudget:      d.Get("max_budget").(float64),
+		BudgetDuration: d.Get("budget_duration").(string),
+		Models:         models,
+		Blocked:        d.Get("blocked").(bool),
+	}
+
+	return team
+}
+
+func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*LitellmClient)
+
+	var diags diag.Diagnostics
+
+	team := getTeamFromResourceData(d)
+	jsonData, err := json.Marshal(team)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	url := fmt.Sprintf("%s/team/new", client.ApiBaseURL)
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return diag.Errorf("API Request to create the team has failed with status code %d", resp.StatusCode)
+	}
+
+	d.SetId(team.TeamId)
+
+	return diags
+}
+
+func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*LitellmClient)
+
+	var diags diag.Diagnostics
+
+	teamId := d.Get("team_id").(string)
+	apiUrl := fmt.Sprintf("%s/team/info?team_id=%s", client.ApiBaseURL, teamId)
+
+	req, err := client.NewRequest("GET", apiUrl, nil)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	var teamInfo litellm.TeamInfoResponse
+	// body := make(map[string]interface{})
+	err = json.NewDecoder(resp.Body).Decode(&teamInfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(teamInfo.TeamId)
+	d.Set("team_id", teamInfo.TeamId)
+	d.Set("team_alias", teamInfo.TeamInfo.TeamAlias)
+	d.Set("metadata", teamInfo.TeamInfo.Metadata)
+	d.Set("tpm_limit", teamInfo.TeamInfo.TpmLimit)
+	d.Set("rpm_limit", teamInfo.TeamInfo.RpmLimit)
+	d.Set("blocked", teamInfo.TeamInfo.Blocked)
+	d.Set("models", teamInfo.TeamInfo.Models)
+	d.Set("budget_duration", teamInfo.TeamInfo.BudgetDuration)
+	d.Set("max_budget", teamInfo.TeamInfo.MaxBudget)
+
+	if resp.StatusCode != http.StatusOK {
+		return diag.Errorf("API Request to read the team has failed with status code %d", resp.StatusCode)
+	}
+
+	return diags
+}
+
+func resourceTeamUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*LitellmClient)
+
+	var diags diag.Diagnostics
+
+	team := getTeamFromResourceData(d)
+
+	apiUrlUpdateTeam := fmt.Sprintf("%s/team/update", client.ApiBaseURL)
+	teamUpdateBody, err := json.Marshal(team)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	req, err := client.NewRequest("POST", apiUrlUpdateTeam, bytes.NewBuffer(teamUpdateBody))
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return diag.Errorf("API Request to update the team has failed with status code %d", resp.StatusCode)
+	}
+
+	return diags
+}
+
+func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*LitellmClient)
+
+	var diags diag.Diagnostics
+
+	teamId := d.Get("team_id").(string)
+	teamsToDelete := []string{}
+	teamsToDelete = append(teamsToDelete, teamId)
+	jsonPayload := map[string]interface{}{
+		"team_ids": teamsToDelete,
+	}
+	body, err := json.Marshal(jsonPayload)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	apiUrl := fmt.Sprintf("%s/team/delete", client.ApiBaseURL)
+	req, err := client.NewRequest("POST", apiUrl, bytes.NewBuffer(body))
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		diag.Errorf("API Request to delete the team has failed with status code %d", resp.StatusCode)
+	}
+
+	d.SetId("")
+
+	return diags
+}

--- a/provider/resource_team_test.go
+++ b/provider/resource_team_test.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceTeamCreateUpdateDelete(t *testing.T) {
+	apiToken := "test-token"
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	valueRead := map[string]interface{}{
+		"team_id": "mock-team-read",
+		"team_info": map[string]interface{}{
+			"team_alias": "mock-team",
+			"metadata": map[string]interface{}{
+				"test-metadata": "mock-value",
+			},
+			"tpm_limit":       20,
+			"rpm_limit":       10,
+			"max_budget":      250.25,
+			"budget_duration": "30d",
+			"models":          []interface{}{"azure/gpt-4o"},
+			"blocked":         false,
+		},
+	}
+
+	mux.HandleFunc("/team/info", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		expectedToken := fmt.Sprintf("Bearer %s", apiToken)
+
+		assert.Equal(t, expectedToken, token)
+
+		jsonOutput, err := json.Marshal(valueRead)
+		if err != nil {
+			panic(err)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonOutput)
+	})
+
+	mux.HandleFunc("/team/update", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		expectedToken := fmt.Sprintf("Bearer %s", apiToken)
+
+		assert.Equal(t, expectedToken, token)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	})
+
+	mux.HandleFunc("/team/delete", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		expectedToken := fmt.Sprintf("Bearer %s", apiToken)
+
+		assert.Equal(t, expectedToken, token)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	})
+
+	mux.HandleFunc("/team/new", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		expectedToken := fmt.Sprintf("Bearer %s", apiToken)
+
+		assert.Equal(t, expectedToken, token)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	})
+
+	p := NewProvider()
+	providerConfig := schema.TestResourceDataRaw(t, p.Schema, map[string]interface{}{
+		"api_token":    apiToken,
+		"api_base_url": server.URL,
+	})
+
+	meta, diags := p.ConfigureContextFunc(context.Background(), providerConfig)
+	if diags.HasError() {
+		t.Fatalf("Failed to configure provider: %s", diags[0].Summary)
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, p.ResourcesMap["litellm_team"].Schema, map[string]interface{}{
+		"team_id":    "mock-team",
+		"team_alias": "mock-team",
+		"metadata": map[string]interface{}{
+			"test-metadata": "mock-value",
+		},
+		"tpm_limit":       20,
+		"rpm_limit":       10,
+		"max_budget":      250.25,
+		"budget_duration": "30d",
+		"models":          []interface{}{"azure/gpt-4o"},
+		"blocked":         false,
+	})
+
+	updateResourceData := schema.TestResourceDataRaw(t, p.ResourcesMap["litellm_team"].Schema, map[string]interface{}{
+		"team_id":    "mock-team",
+		"team_alias": "mock-team-updated",
+		"metadata": map[string]interface{}{
+			"test-metadata": "mock-value",
+		},
+		"tpm_limit":       20,
+		"rpm_limit":       10,
+		"max_budget":      250.25,
+		"budget_duration": "30d",
+		"models":          []interface{}{"azure/gpt-4o"},
+		"blocked":         false,
+	})
+
+	readResourceData := schema.TestResourceDataRaw(t, p.ResourcesMap["litellm_team"].Schema, valueRead)
+
+	// Test Create
+	diags = p.ResourcesMap["litellm_team"].CreateContext(context.Background(), resourceData, meta)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "mock-team", resourceData.Get("team_id").(string))
+
+	// Test Update
+	diags = p.ResourcesMap["litellm_team"].UpdateContext(context.Background(), updateResourceData, meta)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "mock-team-updated", updateResourceData.Get("team_alias").(string))
+	assert.Equal(t, "mock-value", updateResourceData.Get("metadata").(map[string]interface{})["test-metadata"].(string))
+
+	// Test Delete
+	diags = p.ResourcesMap["litellm_team"].DeleteContext(context.Background(), resourceData, meta)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "", resourceData.Id())
+
+	// Test Read
+	diags = p.ResourcesMap["litellm_team"].ReadContext(context.Background(), readResourceData, meta)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "mock-team-read", readResourceData.Get("team_id").(string))
+	assert.Equal(t, "mock-team-read", readResourceData.Id())
+}


### PR DESCRIPTION
This PR is dependent of https://github.com/gzamboni/terraform-provider-litellm/pull/6

## Changes

Added the code to support creating/delete/updating team with the provider

## Testing

Wrote a test file, to test the big thing

But I tested it with this file against a locally litellm instance.

```hcl
resource "litellm_team" "example_team" {
  team_id = "my-team-id"
  team_alias = "my-team-id"
  tpm_limit = 10
  rpm_limit = 20
  max_budget = 100.0
  metadata = {
    "project" = "my-project"
  }
}
```

## Why there is no member attribute

I didnt put the attribute to add a member to the team because it is kind of sketchy to do it actually with the /team API
with /team/new you can provide an attribute "members_with_roles" to add member to the team. But when updating wi /team/update you can't update "members_with_roles".

So I believe it will be simpler to add later, a resource "litellm_team_membership" working with /team/member_add, /team/member_update, /team/member_delete, and /team/info for ReadContext for this resource.