### PR TITLE
feat!: add model api read and datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ bin/
 
 dist/
 terraform-provider-litellm
+.vscode

--- a/provider/client.go
+++ b/provider/client.go
@@ -1,6 +1,21 @@
 package provider
 
+import (
+	"io"
+	"net/http"
+)
+
 type LitellmClient struct {
 	ApiToken   string `tfsdk:"api_token"`
 	ApiBaseURL string `tfsdk:"api_base_url"`
+}
+
+func (c *LitellmClient) NewRequest(method string, url string, body io.Reader) (*http.Request, error) {
+	request, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("Authorization", "Bearer "+c.ApiToken)
+	return request, nil
 }

--- a/provider/datasource_model.go
+++ b/provider/datasource_model.go
@@ -1,0 +1,291 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/url"
+
+	"github.com/gzamboni/terraform-provider-litellm/provider/litellm"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var DatasourceModelInfoSchema = map[string]*schema.Schema{
+	"model_info_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "",
+	},
+	"model_info_db_model": {
+		Type:        schema.TypeBool,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"model_info_tier": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"model_info_base_model": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"model_info_updated_at": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+	"model_info_updated_by": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+	"model_info_created_at": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+	"model_info_created_by": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+}
+
+var DatasourceLitellmParamsSchema = map[string]*schema.Schema{
+	"litellm_params_model": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_custom_llm_provider": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_tpm": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_rpm": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_api_key": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_api_base": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_api_version": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_timeout": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_stream_timeout": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_max_retries": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_organization": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_configurable_clientside_auth_params": {
+		Type:        schema.TypeList,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
+	"litellm_params_region_name": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_vertex_project": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_vertex_location": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_vertex_credentials": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_aws_access_key_id": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_aws_secret_key_id": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_aws_region_name": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_watsonx_region_name": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_input_cost_per_token": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_output_cost_per_token": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_input_cost_per_second": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_output_cost_per_second": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_max_file_size_mb": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+}
+
+var DatasourceBaseModelSchema = map[string]*schema.Schema{
+	"model_name": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "Name of the model to be managed.",
+	},
+}
+
+func DatasourceModelSchema() map[string]*schema.Schema {
+	ModelSchema := make(map[string]*schema.Schema)
+	maps.Copy(ModelSchema, DatasourceBaseModelSchema)
+	maps.Copy(ModelSchema, DatasourceLitellmParamsSchema)
+	maps.Copy(ModelSchema, DatasourceModelInfoSchema)
+	return ModelSchema
+}
+
+func datasourceModel() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceResourceModelRead,
+		Schema:      DatasourceModelSchema(),
+	}
+}
+
+func DatasourceResourceModelRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	client := m.(*LitellmClient)
+
+	modelId := d.Get("model_info_id").(string)
+
+	params := url.Values{}
+	params.Add("litellm_model_id", modelId)
+	apiUrl := fmt.Sprintf("%s/model/info?%s", client.ApiBaseURL, params.Encode())
+
+	req, err := client.NewRequest(http.MethodGet, apiUrl, nil)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		diag.Errorf("API Request to read model info returned status code %d", resp.StatusCode)
+	}
+
+	var jsonPayload litellm.ModelInfoWModelId
+	err = json.NewDecoder(resp.Body).Decode(&jsonPayload)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	rModel := &jsonPayload.Data
+
+	d.SetId(rModel.ModelInfo.Id)
+	setResourceDataFromModel(rModel, d)
+
+	return diags
+}

--- a/provider/datasource_model_test.go
+++ b/provider/datasource_model_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatasourceModelRead(t *testing.T) {
+	// Mock LiteLLM API server
+	apiToken := "test-token"
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/model/info", func(w http.ResponseWriter, r *http.Request) {
+		readOutput := map[string]interface{}{
+			"data": map[string]interface{}{"model_name": "test-model",
+				"model_info": map[string]string{
+					"id":         "unique-model-id",
+					"base_model": "gpt-3.5-turbo",
+					"tier":       "paid",
+				},
+				"litellm_params": map[string]string{
+					"custom_llm_provider": "openai",
+					"model":               "gpt-3.5-turbo",
+					"api_key":             "underlying-api-key",
+				},
+			},
+		}
+
+		jsonOutput, err := json.Marshal(readOutput)
+		if err != nil {
+			panic(err)
+		}
+
+		token := r.Header.Get("Authorization")
+		expectedToken := fmt.Sprintf("Bearer %s", apiToken)
+		assert.Equal(t, expectedToken, token)
+
+		litellm_model_id := r.URL.Query().Get("litellm_model_id")
+		assert.Equal(t, "unique-model-id", litellm_model_id)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonOutput)
+	})
+
+	// Configure the provider with the mock server URL
+	p := NewProvider()
+
+	// Create provider configuration data
+	providerConfig := schema.TestResourceDataRaw(t, p.Schema, map[string]interface{}{
+		"api_token":    apiToken,
+		"api_base_url": server.URL,
+	})
+
+	// Call ConfigureContextFunc and get the meta (client)
+	meta, diags := p.ConfigureContextFunc(context.Background(), providerConfig)
+	if diags.HasError() {
+		t.Fatalf("Failed to configure provider: %s", diags[0].Summary)
+	}
+
+	readResosurceData := schema.TestResourceDataRaw(t, p.DataSourcesMap["litellm_model"].Schema, map[string]interface{}{
+		"model_info_id": "unique-model-id",
+	})
+
+	// Test Read
+	diags = p.DataSourcesMap["litellm_model"].ReadContext(context.Background(), readResosurceData, meta)
+	assert.False(t, diags.HasError())
+}

--- a/provider/litellm/model.go
+++ b/provider/litellm/model.go
@@ -1,0 +1,54 @@
+package litellm
+
+type ModelInfo struct {
+	Id        string `json:"id,omitempty"`
+	DbModel   bool   `json:"db_model"`
+	Tier      string `json:"tier,omitempty"`
+	BaseModel string `json:"base_model,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+	UpdatedBy string `json:"updated_by,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	CreatedBy string `json:"create_by,omitempty"`
+}
+
+type LitellmParams struct {
+	Model                            string   `json:"model"`
+	CustomLlmProvider                string   `json:"custom_llm_provider,omitempty"`
+	Tpm                              int      `json:"tpm,omitempty"`
+	Rpm                              int      `json:"rpm,omitempty"`
+	ApiKey                           string   `json:"api_key,omitempty"`
+	ApiBase                          string   `json:"api_base,omitempty"`
+	ApiVersion                       string   `json:"api_version,omitempty"`
+	Timeout                          float64  `json:"timeout,omitempty"`
+	StreamTimeout                    float64  `json:"stream_timeout,omitempty"`
+	MaxRetries                       int      `json:"max_retries,omitempty"`
+	Organization                     string   `json:"organization,omitempty"`
+	ConfigurableClientsideAuthParams []string `json:"configurable_clientside_auth_params,omitempty"`
+	RegionName                       string   `json:"region_name,omitempty"`
+	VertexProject                    string   `json:"vertex_project,omitempty"`
+	VertexLocation                   string   `json:"vertex_location,omitempty"`
+	VertexCredentials                string   `json:"vertex_credentials,omitempty"`
+	AwsAccessKeyId                   string   `json:"aws_access_key_id,omitempty"`
+	AwsSecretKeyId                   string   `json:"aws_secret_key_id,omitempty"`
+	AwsRegionName                    string   `json:"aws_region_name,omitempty"`
+	WatsonxRegionName                string   `json:"watsonx_region_name,omitempty"`
+	InputCostPerToken                float64  `json:"input_cost_per_token,omitempty"`
+	OutputCostPerToken               float64  `json:"output_cost_per_token,omitempty"`
+	InputCostPerSecond               float64  `json:"input_cost_per_second,omitempty"`
+	OutputCostPerSecond              float64  `json:"output_cost_per_second,omitempty"`
+	MaxFileSizeMB                    float64  `json:"max_file_size_mb,omitempty"`
+}
+
+type Model struct {
+	ModelName     string        `json:"model_name"`
+	LitellmParams LitellmParams `json:"litellm_params"`
+	ModelInfo     ModelInfo     `json:"model_info"`
+}
+
+type ModelInfoWoModelId struct {
+	Data []Model `json:"data"`
+}
+
+type ModelInfoWModelId struct {
+	Data Model `json:"data"`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -27,6 +27,9 @@ func NewProvider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"litellm_model": resourceModel(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"litellm_model": datasourceModel(),
+		},
 		ConfigureContextFunc: providerConfigure,
 	}
 }

--- a/provider/resource_model.go
+++ b/provider/resource_model.go
@@ -73,13 +73,10 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/new", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -130,13 +127,10 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/update", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -171,13 +165,10 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	url := fmt.Sprintf("%s/model/delete", client.ApiBaseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := client.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.ApiToken))
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/provider/resource_model.go
+++ b/provider/resource_model.go
@@ -5,11 +5,356 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
+	"net/url"
 
+	"github.com/gzamboni/terraform-provider-litellm/provider/litellm"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func SupressIgnoreChange(k, old, new string, d *schema.ResourceData) bool {
+	return true
+}
+
+var ModelInfoSchema = map[string]*schema.Schema{
+	"model_info_id": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "",
+	},
+	"model_info_db_model": {
+		Type:        schema.TypeBool,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+		Default:     true,
+	},
+	"model_info_tier": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"model_info_base_model": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"model_info_updated_at": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+	"model_info_updated_by": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+	"model_info_created_at": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+	"model_info_created_by": {
+		Type:                  schema.TypeString,
+		Required:              false,
+		Optional:              true,
+		Description:           "",
+		DiffSuppressOnRefresh: true,
+		DiffSuppressFunc:      SupressIgnoreChange,
+	},
+}
+
+var LitellmParamsSchema = map[string]*schema.Schema{
+	"litellm_params_model": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "",
+	},
+	"litellm_params_custom_llm_provider": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_tpm": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_rpm": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_api_key": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_api_base": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_api_version": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_timeout": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_stream_timeout": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_max_retries": {
+		Type:        schema.TypeInt,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_organization": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_configurable_clientside_auth_params": {
+		Type:        schema.TypeList,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
+	"litellm_params_region_name": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_vertex_project": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_vertex_location": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_vertex_credentials": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_aws_access_key_id": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_aws_secret_key_id": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_aws_region_name": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_watsonx_region_name": {
+		Type:        schema.TypeString,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_input_cost_per_token": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_output_cost_per_token": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_input_cost_per_second": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_output_cost_per_second": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+	"litellm_params_max_file_size_mb": {
+		Type:        schema.TypeFloat,
+		Required:    false,
+		Optional:    true,
+		Description: "",
+	},
+}
+
+var BaseModelSchema = map[string]*schema.Schema{
+	"model_name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Name of the model to be managed.",
+	},
+}
+
+func ModelSchema() map[string]*schema.Schema {
+	ModelSchema := make(map[string]*schema.Schema)
+	maps.Copy(ModelSchema, BaseModelSchema)
+	maps.Copy(ModelSchema, LitellmParamsSchema)
+	maps.Copy(ModelSchema, ModelInfoSchema)
+	return ModelSchema
+}
+
+func getModelInfoFromResourceData(d *schema.ResourceData) litellm.ModelInfo {
+	data := litellm.ModelInfo{
+		Id:        d.Get("model_info_id").(string),
+		DbModel:   d.Get("model_info_db_model").(bool),
+		Tier:      d.Get("model_info_tier").(string),
+		BaseModel: d.Get("model_info_base_model").(string),
+		UpdatedAt: d.Get("model_info_updated_at").(string),
+		UpdatedBy: d.Get("model_info_updated_by").(string),
+		CreatedAt: d.Get("model_info_created_at").(string),
+		CreatedBy: d.Get("model_info_created_by").(string),
+	}
+
+	return data
+}
+
+func setModelInfoFromModel(model *litellm.Model, d *schema.ResourceData) {
+	d.Set("model_info_id", model.ModelInfo.Id)
+	d.Set("model_info_db_model", model.ModelInfo.DbModel)
+	d.Set("model_info_tier", model.ModelInfo.Tier)
+	d.Set("model_info_base_model", model.ModelInfo.BaseModel)
+	d.Set("model_info_updated_at", model.ModelInfo.UpdatedAt)
+	d.Set("model_info_updated_by", model.ModelInfo.UpdatedBy)
+	d.Set("model_info_created_at", model.ModelInfo.CreatedAt)
+	d.Set("model_info_created_by", model.ModelInfo.CreatedBy)
+}
+
+func getLitellmParamsFromResourceData(d *schema.ResourceData) litellm.LitellmParams {
+	rawConfigurableClientsideConfigParams := d.Get("litellm_params_configurable_clientside_auth_params").([]interface{})
+	var configurableClientsideConfigParams []string
+	for _, item := range rawConfigurableClientsideConfigParams {
+		configurableClientsideConfigParams = append(configurableClientsideConfigParams, item.(string))
+	}
+
+	data := litellm.LitellmParams{
+		Model:                            d.Get("litellm_params_model").(string),
+		CustomLlmProvider:                d.Get("litellm_params_custom_llm_provider").(string),
+		Tpm:                              d.Get("litellm_params_tpm").(int),
+		Rpm:                              d.Get("litellm_params_rpm").(int),
+		ApiKey:                           d.Get("litellm_params_api_key").(string),
+		ApiBase:                          d.Get("litellm_params_api_base").(string),
+		ApiVersion:                       d.Get("litellm_params_api_version").(string),
+		Timeout:                          d.Get("litellm_params_timeout").(float64),
+		StreamTimeout:                    d.Get("litellm_params_stream_timeout").(float64),
+		MaxRetries:                       d.Get("litellm_params_max_retries").(int),
+		Organization:                     d.Get("litellm_params_organization").(string),
+		ConfigurableClientsideAuthParams: configurableClientsideConfigParams,
+		RegionName:                       d.Get("litellm_params_region_name").(string),
+		VertexProject:                    d.Get("litellm_params_vertex_project").(string),
+		VertexLocation:                   d.Get("litellm_params_vertex_location").(string),
+		VertexCredentials:                d.Get("litellm_params_vertex_credentials").(string),
+		AwsAccessKeyId:                   d.Get("litellm_params_aws_access_key_id").(string),
+		AwsSecretKeyId:                   d.Get("litellm_params_aws_secret_key_id").(string),
+		AwsRegionName:                    d.Get("litellm_params_aws_region_name").(string),
+		WatsonxRegionName:                d.Get("litellm_params_watsonx_region_name").(string),
+		InputCostPerToken:                d.Get("litellm_params_input_cost_per_token").(float64),
+		OutputCostPerToken:               d.Get("litellm_params_output_cost_per_token").(float64),
+		OutputCostPerSecond:              d.Get("litellm_params_output_cost_per_second").(float64),
+		InputCostPerSecond:               d.Get("litellm_params_input_cost_per_second").(float64),
+		MaxFileSizeMB:                    d.Get("litellm_params_max_file_size_mb").(float64),
+	}
+
+	return data
+}
+
+func setLitellmParamsFromModel(model *litellm.Model, d *schema.ResourceData) {
+	d.Set("litellm_params_model", model.LitellmParams.Model)
+	d.Set("litellm_params_custom_llm_provider", model.LitellmParams.CustomLlmProvider)
+	d.Set("litellm_params_tpm", model.LitellmParams.Tpm)
+	d.Set("litellm_params_rpm", model.LitellmParams.Rpm)
+	d.Set("litellm_params_api_key", model.LitellmParams.ApiKey)
+	d.Set("litellm_params_api_base", model.LitellmParams.ApiBase)
+	d.Set("litellm_params_api_version", model.LitellmParams.ApiVersion)
+	d.Set("litellm_params_timeout", model.LitellmParams.Timeout)
+	d.Set("litellm_params_stream_timeout", model.LitellmParams.StreamTimeout)
+	d.Set("litellm_params_max_retries", model.LitellmParams.MaxRetries)
+	d.Set("litellm_params_organization", model.LitellmParams.Organization)
+	d.Set("litellm_params_configurable_clientside_auth_params", model.LitellmParams.ConfigurableClientsideAuthParams)
+	d.Set("litellm_params_region_name", model.LitellmParams.RegionName)
+	d.Set("litellm_params_vertex_project", model.LitellmParams.VertexProject)
+	d.Set("litellm_params_vertex_location", model.LitellmParams.VertexLocation)
+	d.Set("litellm_params_vertex_credentials", model.LitellmParams.VertexCredentials)
+	d.Set("litellm_params_aws_access_key_id", model.LitellmParams.AwsAccessKeyId)
+	d.Set("litellm_params_aws_secret_key_id", model.LitellmParams.AwsSecretKeyId)
+	d.Set("litellm_params_aws_region_name", model.LitellmParams.AwsRegionName)
+	d.Set("litellm_params_watsonx_region_name", model.LitellmParams.WatsonxRegionName)
+	d.Set("litellm_params_input_cost_per_token", model.LitellmParams.InputCostPerToken)
+	d.Set("litellm_params_input_cost_per_second", model.LitellmParams.InputCostPerSecond)
+	d.Set("litellm_params_output_cost_per_token", model.LitellmParams.OutputCostPerToken)
+	d.Set("litellm_params_output_cost_per_second", model.LitellmParams.OutputCostPerSecond)
+	d.Set("litellm_params_max_file_size_mb", model.LitellmParams.MaxFileSizeMB)
+}
+
+func getModelFromResourceData(d *schema.ResourceData) litellm.Model {
+	data := litellm.Model{
+		ModelName:     d.Get("model_name").(string),
+		LitellmParams: getLitellmParamsFromResourceData(d),
+		ModelInfo:     getModelInfoFromResourceData(d),
+	}
+
+	return data
+}
+
+func setResourceDataFromModel(model *litellm.Model, d *schema.ResourceData) {
+	setLitellmParamsFromModel(model, d)
+	setModelInfoFromModel(model, d)
+	d.Set("model_name", model.ModelName)
+}
 
 func resourceModel() *schema.Resource {
 	return &schema.Resource{
@@ -17,34 +362,7 @@ func resourceModel() *schema.Resource {
 		ReadContext:   resourceModelRead,
 		UpdateContext: resourceModelUpdate,
 		DeleteContext: resourceModelDelete,
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of the model.",
-			},
-			"model_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Name of the model to be managed.",
-			},
-			"litellm_params": {
-				Type:        schema.TypeMap,
-				Required:    true,
-				Description: "Parameters for the model as per LiteLLM API.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"model_info": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Description: "Additional model information.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Schema:        ModelSchema(),
 	}
 }
 
@@ -53,19 +371,7 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, m interfac
 
 	var diags diag.Diagnostics
 
-	modelName := d.Get("model_name").(string)
-	litellmParams := d.Get("litellm_params").(map[string]interface{})
-	modelInfo, _ := d.Get("model_info").(map[string]interface{})
-
-	if modelInfo == nil || modelInfo["id"] == nil {
-		return diag.Errorf("model_info.id is required")
-	}
-
-	requestBody := map[string]interface{}{
-		"model_name":     modelName,
-		"litellm_params": litellmParams,
-		"model_info":     modelInfo,
-	}
+	requestBody := getModelFromResourceData(d)
 
 	jsonData, err := json.Marshal(requestBody)
 	if err != nil {
@@ -88,17 +394,46 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.Errorf("API request failed with status code %d", resp.StatusCode)
 	}
 
-	// Set the ID of the resource
-	d.SetId(modelInfo["id"].(string))
+	d.SetId(requestBody.ModelInfo.Id)
 
 	return diags
 }
 
 func resourceModelRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	// Implement the Read function if the API supports it
 
-	// For now, we'll assume the resource always exists
+	client := m.(*LitellmClient)
+
+	stateModel := getModelFromResourceData(d)
+
+	params := url.Values{}
+	params.Add("litellm_model_id", stateModel.ModelInfo.Id)
+	apiUrl := fmt.Sprintf("%s/model/info?%s", client.ApiBaseURL, params.Encode())
+
+	req, err := client.NewRequest(http.MethodGet, apiUrl, nil)
+	if err != nil {
+		diag.FromErr(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		diag.Errorf("API Request to read model info returned status code : %d", resp.StatusCode)
+	}
+
+	var jsonPayload litellm.ModelInfoWModelId
+	err = json.NewDecoder(resp.Body).Decode(&jsonPayload)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	rModel := &jsonPayload.Data
+
+	setResourceDataFromModel(rModel, d)
+
 	return diags
 }
 
@@ -107,19 +442,7 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 
 	var diags diag.Diagnostics
 
-	modelName := d.Get("model_name").(string)
-	litellmParams := d.Get("litellm_params").(map[string]interface{})
-	modelInfo, _ := d.Get("model_info").(map[string]interface{})
-
-	if modelInfo == nil || modelInfo["id"] == nil {
-		return diag.Errorf("model_info.id is required")
-	}
-
-	requestBody := map[string]interface{}{
-		"model_name":     modelName,
-		"litellm_params": litellmParams,
-		"model_info":     modelInfo,
-	}
+	requestBody := getModelFromResourceData(d)
 
 	jsonData, err := json.Marshal(requestBody)
 	if err != nil {
@@ -150,16 +473,13 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, m interfac
 
 	var diags diag.Diagnostics
 
-	modelInfo := d.Get("model_info").(map[string]interface{})
-	if modelInfo == nil || modelInfo["id"] == nil {
-		return diag.Errorf("model_info.id is required")
+	model := getModelFromResourceData(d)
+
+	jsonPayload := map[string]interface{}{
+		"id": model.ModelInfo.Id,
 	}
 
-	requestBody := map[string]interface{}{
-		"id": modelInfo["id"].(string),
-	}
-
-	jsonData, err := json.Marshal(requestBody)
+	jsonData, err := json.Marshal(jsonPayload)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## PR Dependencies 

Http request authorization : https://github.com/gzamboni/terraform-provider-litellm/pull/6 

## Changes

Added datasource litellm_model and the ReadContext for model resource

Also introduced multiple structs representing the Litellm model and model api responses.

I had to change the schema.Schema of the resource Model

## Testing

```hcl
resource "litellm_model" "example" {
  model_name = "example-model"

  litellm_params_custom_llm_provider = "openai"
  litellm_params_model               = "gpt-3.5-turbo"
  litellm_params_api_key             = "your_underlying_model_api_key"
  litellm_params_api_base            = "https://api.openai.com/v1"

  model_info_id  = "mysupermymodel"
  model_info_base_model = "gpt-3.5-turbo"
  model_info_tier       = "paid"
}

data "litellm_model" "example_dt" {
  model_info_id = "4d73f0a13ad754cb37f0dc0d1afb5cd08da9288ed1744560e18b84af7960af41"
}

output "litellm_model_name"{
  value = data.litellm_model.example_dt.model_name
}
```

Tested to read a model created by the config, it's working.
Read/update/delete/create model is working.
